### PR TITLE
Pass async loaded translations to Blockly initialization

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/Ode.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/Ode.java
@@ -28,6 +28,7 @@ import com.google.appinventor.client.boxes.SourceStructureBox;
 import com.google.appinventor.client.boxes.ViewerBox;
 import com.google.appinventor.client.editor.EditorManager;
 import com.google.appinventor.client.editor.FileEditor;
+import com.google.appinventor.client.editor.youngandroid.i18n.BlocklyMsg;
 import com.google.appinventor.client.editor.youngandroid.BlocklyPanel;
 import com.google.appinventor.client.editor.youngandroid.TutorialPanel;
 import com.google.appinventor.client.explorer.commands.ChainableCommand;
@@ -781,12 +782,17 @@ public class Ode implements EntryPoint {
         // load the user's backpack if we are not using a shared
         // backpack
 
-        String backPackId = user.getBackpackId();
+        final String backPackId = user.getBackpackId();
         if (backPackId == null || backPackId.isEmpty()) {
           loadBackpack();
           OdeLog.log("backpack: No shared backpack");
         } else {
-          BlocklyPanel.setSharedBackpackId(backPackId);
+          BlocklyMsg.Loader.ensureTranslationsLoaded(new BlocklyMsg.LoadCallback() {
+            @Override
+            public void call() {
+              BlocklyPanel.setSharedBackpackId(backPackId);
+            }
+          });
           OdeLog.log("Have a shared backpack backPackId = " + backPackId);
         }
 
@@ -1642,6 +1648,7 @@ public class Ode implements EntryPoint {
         userSettings.saveSettings(null);
       }
     }
+    BlocklyMsg.Loader.ensureTranslationsLoaded();
     return true;
   }
 
@@ -2643,8 +2650,13 @@ public class Ode implements EntryPoint {
   private void loadBackpack() {
     userInfoService.getUserBackpack(new AsyncCallback<String>() {
         @Override
-        public void onSuccess(String backpack) {
-          BlocklyPanel.setInitialBackpack(backpack);
+        public void onSuccess(final String backpack) {
+          BlocklyMsg.Loader.ensureTranslationsLoaded(new BlocklyMsg.LoadCallback() {
+            @Override
+            public void call() {
+              BlocklyPanel.setInitialBackpack(backpack);
+            }
+          });
         }
         @Override
         public void onFailure(Throwable caught) {

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/BlocklyPanel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/BlocklyPanel.java
@@ -6,6 +6,8 @@
 
 package com.google.appinventor.client.editor.youngandroid;
 
+import static com.google.appinventor.client.Ode.MESSAGES;
+
 import com.google.appinventor.client.ComponentsTranslation;
 import com.google.appinventor.client.ConnectProgressBar;
 import com.google.appinventor.client.DesignToolbar;
@@ -14,7 +16,6 @@ import com.google.appinventor.client.Ode;
 import com.google.appinventor.client.TopToolbar;
 import com.google.appinventor.client.editor.youngandroid.i18n.BlocklyMsg;
 import com.google.appinventor.client.output.OdeLog;
-import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.appinventor.client.settings.user.BlocksSettings;
 import com.google.appinventor.components.common.YaVersion;
 import com.google.appinventor.shared.settings.SettingsConstants;
@@ -26,21 +27,17 @@ import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.i18n.client.LocaleInfo;
-
 import com.google.gwt.query.client.builders.JsniBundle;
-
+import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.Button;
 import com.google.gwt.user.client.ui.DialogBox;
 import com.google.gwt.user.client.ui.HTML;
 import com.google.gwt.user.client.ui.HTMLPanel;
 import com.google.gwt.user.client.ui.HorizontalPanel;
 import com.google.gwt.user.client.ui.VerticalPanel;
-
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-
-import static com.google.appinventor.client.Ode.MESSAGES;
 
 /**
  * Blocks editor panel.
@@ -53,30 +50,31 @@ import static com.google.appinventor.client.Ode.MESSAGES;
  */
 public class BlocklyPanel extends HTMLPanel {
 
-  public static interface BlocklySource extends JsniBundle {
-    @LibrarySource(value="blockly.js",
-                   prepend="(function(window, document, console){\nthis.goog = goog = top.goog;\n",
-                   postpend="\n}.apply(window, [$wnd, $doc, $wnd.console]));\n" +
-                   "for(var ns in window.goog.implicitNamespaces_) {\n" +
-                   "  if(ns.indexOf('.') !== false) ns = ns.split('.')[0];\n" +
-                   "  top[ns] = window.goog.global[ns];\n" +
-                   "}\nwindow['Blockly'] = top['Blockly'];\nwindow['AI'] = top['AI'];")
-    public void initBlockly();
+  public interface BlocklySource extends JsniBundle {
+    @LibrarySource(value = "blockly.js",
+                   prepend = "(function(window, document, console, _translations){\n"
+                       + "this.goog = goog = top.goog;\n",
+                   postpend = "\n}.apply(window, [$wnd, $doc, $wnd.console, ai2translations]));\n"
+                       + "for(var ns in window.goog.implicitNamespaces_) {\n"
+                       + "  if(ns.indexOf('.') !== false) ns = ns.split('.')[0];\n"
+                       + "  top[ns] = window.goog.global[ns];\n"
+                       + "}\nwindow['Blockly'] = top['Blockly'];\nwindow['AI'] = top['AI'];")
+    void initBlockly(JavaScriptObject ai2translations);
   }
 
-  private static final String EDITOR_HTML = "<div id=\"FORM_NAME\" class=\"svg\" tabindex=\"-1\"></div>";
   private static final NativeTranslationMap SIMPLE_COMPONENT_TRANSLATIONS;
 
   static {
-    ((BlocklySource) GWT.create(BlocklySource.class)).initBlockly();
-    BlocklyMsg.Loader.ensureTranslationsLoaded();
+    ((BlocklySource) GWT.create(BlocklySource.class))
+        .initBlockly(BlocklyMsg.Loader.getTranslations());
     exportMethodsToJavascript();
     // Tell the blockly world about companion versions.
     setLanguageVersion(YaVersion.YOUNG_ANDROID_VERSION, YaVersion.BLOCKS_LANGUAGE_VERSION);
-    setPreferredCompanion(MESSAGES.useCompanion(YaVersion.PREFERRED_COMPANION, YaVersion.PREFERRED_COMPANION + "u"),
-      YaVersion.COMPANION_UPDATE_URL,
-      YaVersion.COMPANION_UPDATE_URL1,
-      YaVersion.COMPANION_UPDATE_EMULATOR_URL);
+    setPreferredCompanion(
+        MESSAGES.useCompanion(YaVersion.PREFERRED_COMPANION, YaVersion.PREFERRED_COMPANION + "u"),
+        YaVersion.COMPANION_UPDATE_URL,
+        YaVersion.COMPANION_UPDATE_URL1,
+        YaVersion.COMPANION_UPDATE_EMULATOR_URL);
     for (int i = 0; i < YaVersion.ACCEPTABLE_COMPANIONS.length; i++) {
       addAcceptableCompanion(YaVersion.ACCEPTABLE_COMPANIONS[i]);
     }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaProjectEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaProjectEditor.java
@@ -20,6 +20,7 @@ import com.google.appinventor.client.editor.ProjectEditorFactory;
 import com.google.appinventor.client.editor.simple.SimpleComponentDatabase;
 import com.google.appinventor.client.editor.simple.components.MockComponent;
 import com.google.appinventor.client.editor.simple.components.MockFusionTablesControl;
+import com.google.appinventor.client.editor.youngandroid.i18n.BlocklyMsg;
 import com.google.appinventor.client.explorer.project.ComponentDatabaseChangeListener;
 import com.google.appinventor.client.explorer.project.Project;
 import com.google.appinventor.client.explorer.project.ProjectChangeListener;
@@ -64,10 +65,11 @@ import java.util.Set;
  *
  * @author lizlooney@google.com (Liz Looney)
  * @author sharon@google.com (Sharon Perl) - added logic for screens in  
- *   DesignToolbar
+ *     DesignToolbar
  */
-public final class YaProjectEditor extends ProjectEditor implements ProjectChangeListener, ComponentDatabaseChangeListener{
-  
+public final class YaProjectEditor extends ProjectEditor implements ProjectChangeListener,
+    ComponentDatabaseChangeListener {
+
   // FileEditors in a YA project come in sets. Every form in the project has 
   // a YaFormEditor for editing the UI, and a YaBlocksEditor for editing the 
   // blocks representation of the program logic. Some day it may also have an 
@@ -109,7 +111,7 @@ public final class YaProjectEditor extends ProjectEditor implements ProjectChang
   private boolean screen1FormLoaded = false;
   private boolean screen1BlocksLoaded = false;
   private boolean screen1Added = false;
-  
+
   /**
    * Returns a project editor factory for {@code YaProjectEditor}s.
    *
@@ -493,7 +495,7 @@ public final class YaProjectEditor extends ProjectEditor implements ProjectChang
   }
 
   private boolean readyToLoadProject() {
-    return externalComponentsLoaded;
+    return BlocklyMsg.Loader.isTranslationLoaded() && externalComponentsLoaded;
   }
 
   private void addBlocksEditor(YoungAndroidBlocksNode blocksNode) {

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/i18n/BlocklyMsg.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/i18n/BlocklyMsg.java
@@ -1,6 +1,7 @@
 package com.google.appinventor.client.editor.youngandroid.i18n;
 
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.resources.client.ClientBundle;
 import com.google.gwt.resources.client.ExternalTextResource;
 import com.google.gwt.resources.client.ResourceCallback;
@@ -40,6 +41,7 @@ public interface BlocklyMsg extends ClientBundle {
     private static boolean translationsLoaded = false;
     private static Set<LoadCallback> pendingCallbacks = new HashSet<>();
     private static boolean loadInitiated = false;
+    private static JavaScriptObject translations = null;
 
     private Loader() {
       // Not instantiable
@@ -106,11 +108,25 @@ public interface BlocklyMsg extends ClientBundle {
       }
     }
 
+    /**
+     * Tests whether the Blockly strings have been loaded. It is preferable to use
+     * {@link #ensureTranslationsLoaded(LoadCallback)} with a callback, which will
+     * be executed when the translations are available rather than continuously polling
+     * this method.
+     *
+     * @return true if the Blockly messages are loaded, otherwise false.
+     */
+    public static boolean isTranslationLoaded() {
+      return translationsLoaded;
+    }
+
+    public static JavaScriptObject getTranslations() {
+      return translations;
+    }
+
     private static native void installTranslations(String translations)/*-{
-        var messages = JSON.parse(translations);
-        Object.keys(messages).forEach(function (key) {
-          Blockly.Msg[key] = messages[key];
-        });
+      @com.google.appinventor.client.editor.youngandroid.i18n.BlocklyMsg.Loader::translations =
+        JSON.parse(translations);
     }-*/;
   }
 }

--- a/appinventor/blocklyeditor/ploverConfig.js
+++ b/appinventor/blocklyeditor/ploverConfig.js
@@ -64,6 +64,7 @@
     '../lib/blockly/core/zoom_controls.js',
 
     //finally, include any of our own .js file in any order
+    "./src/msg.js",
     "./src/events.js",
     "./src/blocklyeditor.js",
     './src/typeblock.js',

--- a/appinventor/blocklyeditor/src/blocks/utilities.js
+++ b/appinventor/blocklyeditor/src/blocks/utilities.js
@@ -14,6 +14,7 @@
 'use strict';
 
 goog.provide('Blockly.Blocks.Utilities');
+goog.require('AI.Blockly.Msg');
 
 // Create a unique object to represent the type InstantInTime,
 // used in the Clock component

--- a/appinventor/blocklyeditor/src/msg.js
+++ b/appinventor/blocklyeditor/src/msg.js
@@ -1,0 +1,13 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2020 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+goog.provide('AI.Blockly.Msg');
+goog.require('Blockly.Msg');
+
+// noinspection JSUnresolvedVariable
+Object.keys(_translations).forEach(function (key) {
+  // noinspection JSUnresolvedVariable
+  Blockly.Msg[key] = _translations[key];
+});


### PR DESCRIPTION
So there are two main challenges that are addressed here.

1. We need to load the Blockly messages before we can load Blockly, but the `goog.provides` call checks for the existence of a namespace and throws an error if it already exists. Therefore, we need to inject the messages loaded at runtime during the Blockly initialization. This is taken care of by the inclusion of src/msg.js, which receives the translations through the lexically scoped `_translations`. This is fed in via the prepend/postpend configuration in BlocklyPanel.js
2. We only want to reference BlocklyPanel after BlocklyMsg has loaded the translations. In Ode, we use BlocklyPanel at multiple points to set up the backpack, so these calls need to be deferred until after the messages are available. Similarly, we can only load a project if the Blockly messages have been loaded, otherwise we would instantiate BlocklyPanel before the block text would be available.

Some of this process would be simplified if we had promises available in App Engine. I implemented an example of what this might look like to initialize Ode in [this branch](https://github.com/ewpatton/appinventor-sources/commit/615c2abb8a6ef9ca29c9d756e451598a2477f083). In an alternative reality where this is available, we could have these pieces of code ask for the promise that BlocklyMsg will get loaded and attach the additional behaviors as then callbacks to the promise. What we have now works but is less elegant.

Change-Id: If4b8a83ddfa3fd79d20b67723331957f018ddda7